### PR TITLE
Replace libappindicator with libayatana-appindicator3 in backend Dockerfile

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -10,7 +10,7 @@ RUN apt-get update -y --allow-insecure-repositories && apt-get install -y \
     unzip \
     xvfb \
     libxss1 \
-    libappindicator1 \
+    libayatana-appindicator3-1 \
     fonts-liberation \
     libnss3 \
     libatk1.0-0 \


### PR DESCRIPTION
## Summary
- Replace deprecated `libappindicator1` with `libayatana-appindicator3-1` in backend Dockerfile to match modern Chrome dependencies

## Testing
- `docker build -f Dockerfile.backend -t backend-test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d68d1b7c832cac3811938283ef33