### PR TITLE
Handle missing stdin for reasoning agent

### DIFF
--- a/api.py
+++ b/api.py
@@ -289,7 +289,11 @@ async def process_query(request: QueryRequest):
         return JSONResponse(status_code=200, content=query_resp.jsonify())
     except Exception as e:
         logger.error(f"An error occurred: {str(e)}")
-        sys.exit(1)
+        is_generating = False
+        query_resp.answer = ""
+        query_resp.reasoning = f"Error: {str(e)}"
+        query_resp.success = "false"
+        return JSONResponse(status_code=500, content=query_resp.jsonify())
     finally:
         logger.info("Processing finished")
         if config.getboolean('MAIN', 'save_session'):

--- a/sources/interaction.py
+++ b/sources/interaction.py
@@ -167,7 +167,7 @@ class Interaction:
         if agent.type == "reasoning_agent":
             pretty_print("This query requires advanced reasoning. Do you want to proceed with the intelligence reasoning endpoint? (y/n)", color="warning")
             confirmation = self.read_stdin()
-            if confirmation.lower() != 'y':
+            if confirmation is not None and confirmation.lower() != 'y':
                 pretty_print("Using normal agent as fallback.", color="status")
                 agent = self.router.get_agent_by_type("casual_agent")
 


### PR DESCRIPTION
## Summary
- Avoid crash when reasoning agent runs without stdin
- Return JSON error instead of exiting server on query failures

## Testing
- `python -m py_compile api.py sources/interaction.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'chromedriver_autoinstaller')*

------
https://chatgpt.com/codex/tasks/task_e_68a4e45c6e34832c89c79cec7748a9cd